### PR TITLE
Minor fix: Include cmath for MSVC, fix namespace "std" has no member "pow"

### DIFF
--- a/applications/cfd_plugin/interfaces/radau5_cpp/radau_cpp.cpp
+++ b/applications/cfd_plugin/interfaces/radau5_cpp/radau_cpp.cpp
@@ -4,14 +4,8 @@
 
 #include <assert.h>
 #include <fenv.h>
-#include <math.h>
+#include <cmath>
 #include <stdio.h>
-
-#include <algorithm>
-#ifdef _MSC_VER
-  #include <cmath>
-  using std::pow;   // MSVC does not pull std::pow from <math.h> or <stdio.h>, only <cmath> adds the template overloads of std::pow
-#endif
 
 namespace radau_cpp {
 

--- a/applications/cfd_plugin/interfaces/radau5_cpp/radau_cpp.cpp
+++ b/applications/cfd_plugin/interfaces/radau5_cpp/radau_cpp.cpp
@@ -8,6 +8,10 @@
 #include <stdio.h>
 
 #include <algorithm>
+#ifdef _MSC_VER
+  #include <cmath>
+  using std::pow;   // MSVC does not pull std::pow from <math.h> or <stdio.h>, only <cmath> adds the template overloads of std::pow
+#endif
 
 namespace radau_cpp {
 


### PR DESCRIPTION
Hi @whitesides1, 

Just found a minor issue here in **radau_cpp.cpp**. MSVC does not pull std::pow from **<math.h>** or **<stdio.h>**, so we encountered an error with "generator": "Visual Studio 17 2022 Win64": 
`
Error (active)	E0135	namespace "std" has no member "pow"	zerork_cfd_plugin.dll (applications\cfd_plugin\zerork_cfd_plugin.dll) - x64-Release. 
`
Only the **\<cmath>** adds the template overloads of **std::pow**. 
Please review the the change.
Thanks,
Kai